### PR TITLE
Add Django cached metadata store

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,8 @@ jobs:
       - run:
           name: Lint code with pylint
           command: ~/.local/bin/pylint --rcfile=pylintrc src tests tests_django
+          environment:
+            DJANGO_SETTINGS_MODULE: tests_django.settings
       - run:
           name: Lint code with bandit
           command: ~/.local/bin/bandit -c .bandit -qr src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ and this project adheres to
 ### Added
 - Federation metadata parser.
 - "Féderation Éducation-Recherche" SAML authentication backend.
+- Django integration: add metadata store with cache
 
 [unreleased]: https://github.com/openfun/social-edu-federation

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ lint-isort:  ## automatically re-arrange python imports in code base
 
 lint-pylint:  ## Run the pylint tool
 	@echo "$(BOLD)Running pylint$(RESET)"
-	pylint --rcfile=pylintrc src tests tests_django
+	DJANGO_SETTINGS_MODULE=tests_django.settings pylint --rcfile=pylintrc src tests tests_django
 .PHONY: lint-pylint
 
 lint-bandit: ## lint back-end python sources with bandit

--- a/pylintrc
+++ b/pylintrc
@@ -22,7 +22,7 @@ jobs=0
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint_pytest
 
 # Pickle collected data for later comparisons.
 persistent=yes

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ dev =
     pyOpenSSL==20.0.1
     pytest==7.1.2
     pytest-cov==3.0.0
+    pytest-freezegun==0.4.2
     pytest-mock==3.7.0
     signxml==2.9.0
     tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ dev =
     isort==5.10.1
     pycodestyle==2.8.0
     pylint==2.13.9
+    pylint-pytest==1.1.2
     pyOpenSSL==20.0.1
     pytest==7.1.2
     pytest-cov==3.0.0

--- a/src/social_edu_federation/django/metadata_store.py
+++ b/src/social_edu_federation/django/metadata_store.py
@@ -1,0 +1,99 @@
+"""Metadata store module using Django's default cache"""
+import datetime
+
+from django.core.cache import InvalidCacheBackendError, cache as default_cache, caches
+
+from social_core.utils import slugify
+
+from social_edu_federation.metadata_store import BaseMetadataStore
+from social_edu_federation.parser import FederationMetadataParser
+
+
+class CacheEntryMixin:
+    """
+    Mix-in to turn `BaseMetadataStore` into a cache object to easily
+    manage object storage in cache.
+
+    This:
+     - adds a namespace to the cached keys,
+     - defines a cache duration of one day,
+       we add a minute to ensure the refreshing management command
+       can pass again.
+     -  uses the default defined cache (you may use a Redis cache in production).
+    """
+
+    namespace = "edu_fed_saml"
+    duration = datetime.timedelta(hours=24, minutes=1).total_seconds()
+    cache = default_cache  # Django default cache
+
+    def _namespaced_key(self, key):
+        """Returns a key for the cache entry."""
+        return f"edu_federation:{self.namespace}:{key}"
+
+    def set_many(self, **kwargs):
+        """
+        Class method to update keys in cache by batch.
+
+        Note: `RenaterCache` does not provide other "many keys" manipulation.
+        This is on purpose, as we don't need this complexity here.
+        """
+        self.cache.set_many(
+            dict((self._namespaced_key(key), value) for key, value in kwargs.items()),
+            self.duration,
+        )
+
+    def get(self, entry_id):
+        """Returns the cache entry value."""
+        return self.cache.get(self._namespaced_key(entry_id))
+
+    def set(self, entry_id, value):
+        """Store the cache entry value."""
+        self.cache.set(self._namespaced_key(entry_id), value, self.duration)
+
+
+class CachedMetadataStore(CacheEntryMixin, BaseMetadataStore):
+    """
+    Implementation of a metadata store for authentication backends with cache.
+
+    Its purpose is to allow the retrieval of Identity Provider configuration
+    from the remote Federation Metadata without parsing data each time.
+    """
+
+    def __init__(self, backend):
+        """Add cache specific configuration."""
+        super().__init__(backend)
+        self._init_cache_settings()
+
+    def _init_cache_settings(self):
+        """Add cache management configuration, use a different namespace for each backend."""
+        self.namespace = slugify(self.backend.name)
+        specified_cache_name = self.backend.setting("DJANGO_CACHE", None)
+        if specified_cache_name:
+            try:
+                self.cache = caches[specified_cache_name]
+            except InvalidCacheBackendError as exception:
+                raise InvalidCacheBackendError(
+                    f"'{specified_cache_name}' does not exist in {list(caches)}"
+                ) from exception
+
+    def refresh_cache_entries(self):
+        """Refetch the metadata, parse them and store values in cache."""
+        xml_metadata = self.fetch_remote_metadata()
+
+        all_idp_dict = FederationMetadataParser.parse_federation_metadata(xml_metadata)
+
+        self.set("all_idps", all_idp_dict)
+        self.set_many(**all_idp_dict)
+
+        return all_idp_dict
+
+    def get_idp(self, idp_name):
+        """Given the name of an IdP, get an SAMLIdentityProvider instance from federation."""
+        idp_configuration = self.get(idp_name)
+        if not idp_configuration:
+            all_configurations = self.refresh_cache_entries()
+            idp_configuration = all_configurations[idp_name]
+
+        return self.backend.edu_fed_saml_idp_class.create_from_config_dict(
+            **idp_configuration
+        )

--- a/tests_django/tests/test_metadata_store.py
+++ b/tests_django/tests/test_metadata_store.py
@@ -1,0 +1,293 @@
+"""Metadata store tests, already tested in full process so this is only unit testing."""
+from copy import deepcopy
+import datetime
+import re
+
+from django.core.cache import InvalidCacheBackendError, cache as default_cache, caches
+from django.utils import timezone
+
+import pytest
+from social_django.utils import load_backend, load_strategy
+
+from social_edu_federation.backends.saml_fer import FERSAMLIdentityProvider
+from social_edu_federation.django.metadata_store import CachedMetadataStore
+from social_edu_federation.parser import FederationMetadataParser
+
+
+class MagicClass:
+    """Mocking class to replace IdP real object"""
+
+    def __init__(self, **kwargs):
+        """Store all provided `kwargs` as attributes"""
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    @classmethod
+    def create_from_config_dict(cls, **kwargs):
+        """Creation method called by the metadata store."""
+        return cls(**kwargs)
+
+
+class MockedBackend:
+    """Fake backend for test purpose only"""
+
+    edu_fed_saml_idp_class = MagicClass
+    name = "mocked-backend"
+
+    def __init__(self, cache_name=None):
+        self.cache_name = cache_name
+
+    def get_federation_metadata_url(self):
+        """Boilerplate to return a fixed URL"""
+        return "https://domain.test/metadata/"
+
+    def setting(self, name, default_value=None):  # pylint: disable=unused-argument
+        """
+        Defines a dummy method to return the cache name,
+        we assert this is the only setting used.
+        """
+        assert name == "DJANGO_CACHE"
+        return self.cache_name
+
+
+@pytest.fixture(name="cache_settings")
+def cache_settings_fixture(settings):
+    """
+    Pytest fixture to override cache settings.
+
+    We need to store the original value because we want to
+    set it again before reloading the initial values of the
+    cache module at the end.
+    """
+    cache_initial_value = deepcopy(settings.CACHES)
+
+    settings.CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "renater_cache_entry_tests",
+        },
+        # add another named cache to test cache change works
+        "some_cache_name": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "renater_cache_entry_tests.some_cache_name",
+        },
+    }
+
+    # Force cache list reloading
+    del caches.settings
+
+    yield
+
+    default_cache.clear()
+
+    settings.CACHES = cache_initial_value
+
+    # Force cache list reloading
+    del caches.settings
+
+
+def test_fetch_remote_metadata(cache_settings, mocker):
+    """Tests `fetch_remote_metadata` method."""
+    store = CachedMetadataStore(MockedBackend())
+
+    get_metadata_mock = mocker.patch.object(FederationMetadataParser, "get_metadata")
+    get_metadata_mock.return_value = b"been called"
+
+    assert store.fetch_remote_metadata() == b"been called"
+
+    get_metadata_mock.assert_called_once_with(
+        "https://domain.test/metadata/", timeout=10
+    )
+
+    # Now call it again, metadata are not cached
+    get_metadata_mock.reset_mock()
+
+    assert store.fetch_remote_metadata() == b"been called"
+
+    assert get_metadata_mock.called
+
+
+@pytest.mark.parametrize(
+    "cache_name",
+    [
+        pytest.param(
+            None,
+            id="use-default-cache",
+        ),
+        pytest.param(
+            "some_cache_name",
+            id="use-named-cache",
+        ),
+    ],
+)
+def test_get_idp(cache_name, cache_settings, freezer, mocker):
+    """
+    Tests `get_idp` method with different values for cache name setting (not defined and defined).
+    """
+    now = timezone.now()
+    store = CachedMetadataStore(MockedBackend(cache_name=cache_name))
+
+    get_metadata_mock = mocker.patch.object(FederationMetadataParser, "get_metadata")
+    get_metadata_mock.return_value = b"been called"
+    parse_metadata_mock = mocker.patch.object(
+        FederationMetadataParser, "parse_federation_metadata"
+    )
+    parse_metadata_mock.return_value = {
+        "some-idp": {
+            "key1": "value1",
+            "key2": "value2",
+        },
+        "other-idp": {
+            "key3": "value3",
+        },
+    }
+
+    magic_instance = store.get_idp("some-idp")
+
+    get_metadata_mock.assert_called_once_with(
+        "https://domain.test/metadata/", timeout=10
+    )
+    parse_metadata_mock.assert_called_once_with(b"been called")
+
+    assert magic_instance.key1 == "value1"
+    assert magic_instance.key2 == "value2"
+    assert not hasattr(magic_instance, "key3")
+
+    cache_to_test = default_cache if cache_name is None else caches[cache_name]
+    assert cache_to_test.get("edu_federation:mocked-backend:some-idp") == {
+        "key1": "value1",
+        "key2": "value2",
+    }
+    assert cache_to_test.get("edu_federation:mocked-backend:other-idp") == {
+        "key3": "value3",
+    }
+    assert cache_to_test.get("edu_federation:mocked-backend:all_idps") == {
+        "other-idp": {"key3": "value3"},
+        "some-idp": {"key1": "value1", "key2": "value2"},
+    }
+
+    # Now call it again and assert cache is used
+    get_metadata_mock.reset_mock()
+    parse_metadata_mock.reset_mock()
+
+    magic_instance_again = store.get_idp("some-idp")
+
+    assert magic_instance_again.key1 == "value1"
+    assert magic_instance_again.key2 == "value2"
+    assert not hasattr(magic_instance_again, "key3")
+
+    assert not get_metadata_mock.called
+    assert not parse_metadata_mock.called
+
+    # Move after the cache expiration
+    freezer.move_to(now + datetime.timedelta(hours=24, minutes=1, seconds=1))
+
+    assert cache_to_test.get("edu_federation:mocked-backend:some-idp") is None
+    assert cache_to_test.get("edu_federation:mocked-backend:other-idp") is None
+    assert cache_to_test.get("edu_federation:mocked-backend:all_idps") is None
+
+    magic_instance_refreshed = store.get_idp("some-idp")
+
+    assert magic_instance_refreshed.key1 == "value1"
+    assert magic_instance_refreshed.key2 == "value2"
+    assert not hasattr(magic_instance_refreshed, "key3")
+
+    get_metadata_mock.assert_called_once_with(
+        "https://domain.test/metadata/", timeout=10
+    )
+    parse_metadata_mock.assert_called_once_with(b"been called")
+
+
+def test_get_idp_named_cache_does_not_exist(settings):
+    """Tests `get_idp` method when the setting for cache is not a valid one."""
+    with pytest.raises(
+        InvalidCacheBackendError,
+        match=re.escape("'invalid' does not exist in ['default']"),
+    ):
+        CachedMetadataStore(MockedBackend(cache_name="invalid"))
+
+
+def test_saml_fer_backend_integration(cache_settings, mocker, settings):
+    """
+    Tests the metadata store with a real backend (`FERSAMLAuth`),
+    without cache name setting (`DJANGO_CACHE`) defined.
+    """
+    settings.AUTHENTICATION_BACKENDS = (
+        "social_edu_federation.backends.saml_fer.FERSAMLAuth",
+    )
+    settings.SOCIAL_AUTH_SAML_FER_FEDERATION_SAML_METADATA_URL = (
+        "https://domain.test/metadata/"
+    )
+
+    strategy = load_strategy()
+    backend = load_backend(strategy, "saml_fer", None)
+
+    store = CachedMetadataStore(backend)
+
+    get_metadata_mock = mocker.patch.object(FederationMetadataParser, "get_metadata")
+    get_metadata_mock.return_value = b"been called"
+    parse_metadata_mock = mocker.patch.object(
+        FederationMetadataParser, "parse_federation_metadata"
+    )
+    parse_metadata_mock.return_value = {
+        "some-idp": {
+            "name": "some-idp",
+            "entityId": "http://some-idp/",
+            "singleSignOnService": {
+                "url": "http://some-idp/ls/",
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+            },
+            "singleLogoutService": {
+                "url": "http://some-idp/slo/",
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+            },
+            # certificate is not validated on creation...
+            "x509cert": "MIIC4DCCAcigAwIBAgIQG...CQZXu/agfMc/tY+miyrD0=",
+            "edu_fed_data": {
+                "display_name": "Some IdP",
+            },
+        },
+        "other-idp": {
+            "name": "other-idp",
+            "entityId": "http://other-idp/",
+            "singleSignOnService": {
+                "url": "http://other-idp/ls/",
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+            },
+            "singleLogoutService": {
+                "url": "http://other-idp/slo/",
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+            },
+            # certificate is not validated on creation...
+            "x509cert": "MIIC4DCCAcigAwIBAgIQG...CQZXu/agfMc/tY+miyrD0=",
+            "edu_fed_data": {
+                "display_name": "Other IdP",
+            },
+        },
+    }
+
+    idp_configuration = store.get_idp("some-idp")
+    assert isinstance(idp_configuration, FERSAMLIdentityProvider)
+
+    get_metadata_mock.assert_called_once_with(
+        "https://domain.test/metadata/", timeout=10
+    )
+    parse_metadata_mock.assert_called_once_with(b"been called")
+
+    assert idp_configuration.name == "some-idp"
+    assert idp_configuration.conf == {
+        "attr_email": "urn:oid:0.9.2342.19200300.100.1.3",
+        "attr_first_name": "urn:oid:2.5.4.42",
+        "attr_full_name": "urn:oid:2.16.840.1.113730.3.1.241",
+        "attr_last_name": "urn:oid:2.5.4.4",
+        "attr_role": "urn:oid:1.3.6.1.4.1.5923.1.1.1.1",
+        "attr_user_permanent_id": "urn:oid:1.3.6.1.4.1.5923.1.1.1.6",
+        "attr_username": "urn:oid:0.9.2342.19200300.100.1.3",
+        #
+        "entity_id": "http://some-idp/",
+        "slo_url": "http://some-idp/slo/",
+        "url": "http://some-idp/ls/",
+        "x509cert": "MIIC4DCCAcigAwIBAgIQG...CQZXu/agfMc/tY+miyrD0=",
+        "x509certMulti": None,
+        "edu_fed_display_name": "Some IdP",
+    }


### PR DESCRIPTION
## Purpose

Add a cached metadata store usable with Django.

## Proposal

This simply adds a new metadata store which uses Django cache management to store the parsed metadata.

- [x] Add cached metadata store
- [x]  Add tests