### PR TITLE
✨(core) add SAML response name cleaning step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,6 @@ and this project adheres to
 - Django integration: add metadata store with cache
 - Django integration: add cache refresh management command.
 - Django integration: add common views for SAML FER backend use.
+- User's first name/last name/full name cleanup pipeline step.
 
 [unreleased]: https://github.com/openfun/social-edu-federation

--- a/src/social_edu_federation/pipeline/__init__.py
+++ b/src/social_edu_federation/pipeline/__init__.py
@@ -1,0 +1,16 @@
+"""
+Project's own pipeline module.
+
+This also provide a default pipeline to use, based on the original
+`DEFAULT_AUTH_PIPELINE` but replacing the `create_user` step with our own.
+"""
+
+from social_core.pipeline import DEFAULT_AUTH_PIPELINE
+
+
+DEFAULT_EDU_FED_AUTH_PIPELINE = tuple(
+    step
+    if step != "social_core.pipeline.user.create_user"
+    else "social_edu_federation.pipeline.user.create_user"
+    for step in DEFAULT_AUTH_PIPELINE
+)

--- a/src/social_edu_federation/pipeline/user.py
+++ b/src/social_edu_federation/pipeline/user.py
@@ -1,0 +1,30 @@
+"""Project's own user regarding steps."""
+from social_core.pipeline.user import create_user as social_create_user
+
+
+def create_user(strategy, details, backend, *args, **kwargs):
+    """
+    Wrapper for `social_core.pipeline.user.create_user` to make
+    a choice between the "last name"/"first name" couple or only the
+    "full name".
+
+    We expect the fullname to be always provided in SAML response but
+    first name and last name may be not. If we are missing one of first/last
+    names then we fallback on using the full name as last name.
+
+    This pipeline step *must* replace `social_core.create_user` as we don't
+    want to mess with the `details` for now.
+    """
+    filtered_details = dict(details)
+
+    first_name = details.get("first_name")
+    last_name = details.get("last_name")
+    full_name = details.get("fullname")
+    if not first_name or not last_name:
+        if not full_name:
+            # Too many data missing, can't continue
+            return None
+        filtered_details["first_name"] = ""
+        filtered_details["last_name"] = full_name
+
+    return social_create_user(strategy, filtered_details, backend, *args, **kwargs)

--- a/tests/pipeline/test_user.py
+++ b/tests/pipeline/test_user.py
@@ -1,0 +1,150 @@
+"""Tests for the project's `user` pipeline steps."""
+import pytest
+from social_core.pipeline import DEFAULT_AUTH_PIPELINE
+
+from social_edu_federation.pipeline import DEFAULT_EDU_FED_AUTH_PIPELINE
+from social_edu_federation.pipeline.user import create_user
+
+
+def test_original_default_pipeline_has_create_user_step():
+    """Asserts we don't try to replace a nonexistent step."""
+    # If this fails, social_edu_federation.pipeline.__init__ must be fixed
+    assert "social_core.pipeline.user.create_user" in DEFAULT_AUTH_PIPELINE
+
+
+def test_social_edu_federation_step_list():
+    """Asserts our step is in our default pipeline."""
+    # If this fails, social_edu_federation.pipeline.__init__ must be fixed
+    assert (
+        "social_edu_federation.pipeline.user.create_user"
+        in DEFAULT_EDU_FED_AUTH_PIPELINE
+    )
+
+
+@pytest.fixture(name="backend_strategy")
+def backend_strategy_fixture():
+    """Fixture to create empty classes for not tested objects."""
+
+    class MockedStrategy:
+        """Fake strategy"""
+
+    class MockedBackend:
+        """Fake authentication backend"""
+
+    return MockedBackend(), MockedStrategy()
+
+
+@pytest.mark.parametrize(
+    "details,expected_details",
+    [
+        pytest.param(
+            {
+                "fullname": "displayName",
+                "first_name": "givenName",
+                "last_name": "surname",
+                "username": "mail",
+                "email": "mail",
+                "role": "eduPersonAffiliation",
+            },
+            {
+                "fullname": "displayName",
+                "first_name": "givenName",
+                "last_name": "surname",
+                "username": "mail",
+                "email": "mail",
+                "role": "eduPersonAffiliation",
+            },
+            id="all_data",
+        ),
+        pytest.param(
+            {
+                "fullname": "displayName",
+                "last_name": "surname",
+                "username": "mail",
+                "email": "mail",
+                "role": "eduPersonAffiliation",
+            },
+            {
+                "fullname": "displayName",
+                "first_name": "",
+                "last_name": "displayName",
+                "username": "mail",
+                "email": "mail",
+                "role": "eduPersonAffiliation",
+            },
+            id="first name missing",
+        ),
+        pytest.param(
+            {
+                "fullname": "displayName",
+                "first_name": "givenName",
+                "username": "mail",
+                "email": "mail",
+                "role": "eduPersonAffiliation",
+            },
+            {
+                "fullname": "displayName",
+                "first_name": "",
+                "last_name": "displayName",
+                "username": "mail",
+                "email": "mail",
+                "role": "eduPersonAffiliation",
+            },
+            id="last name missing",
+        ),
+        pytest.param(
+            {
+                "first_name": "givenName",
+                "last_name": "surname",
+                "username": "mail",
+                "email": "mail",
+                "role": "eduPersonAffiliation",
+            },
+            {
+                "first_name": "givenName",
+                "last_name": "surname",
+                "username": "mail",
+                "email": "mail",
+                "role": "eduPersonAffiliation",
+            },
+            id="full name missing",
+        ),
+    ],
+)
+def test_create_user(details, expected_details, backend_strategy, mocker):
+    """Asserts our `create_user` step filters data properly."""
+    backend, strategy = backend_strategy
+
+    social_create_user_mock = mocker.patch(
+        "social_edu_federation.pipeline.user.social_create_user"
+    )
+    social_create_user_mock.return_value = True
+
+    create_user(backend, details, strategy, 42, some_kwargs=18)
+
+    social_create_user_mock.assert_called_once_with(
+        backend,
+        expected_details,
+        strategy,
+        42,
+        some_kwargs=18,
+    )
+
+
+def test_create_user_not_enough_data(backend_strategy, mocker):
+    """Asserts our `create_user` step quits if not enough data are provided."""
+    backend, strategy = backend_strategy
+
+    social_create_user_mock = mocker.patch(
+        "social_edu_federation.pipeline.user.social_create_user"
+    )
+
+    details = {
+        "username": "mail",
+        "email": "mail",
+        "role": "eduPersonAffiliation",
+    }
+
+    create_user(backend, details, strategy, 42, some_kwargs=18)
+
+    assert social_create_user_mock.call_count == 0


### PR DESCRIPTION
This adds a step to the pipeline to use the user first name and last name
if available or fallback on user full name as last name.