### PR TITLE
🧑‍💻(django) allow fake idp port override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 
 ### Added
 - IDP faker, allow to customize the user attributes.
+- IDP faker, allow to override the port used to generate metadata.
 
 ## [1.0.0] - 2022-06-24
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,20 @@ make run_django
 
 Open it in your browser.
 
+##### Docker
+
+In case you want to plug the testing views in your own project which is run in a Docker container
+you will probably need to define the port used in the generated metadata. By default,
+it will use the Django application port (let's say 8000) but if your mapping to the container
+uses another port you have to define `SOCIAL_AUTH_SAML_FER_IDP_FAKER_DOCKER_PORT` setting
+to provide the proper port.
+
+E.g.:
+ - Without override: metadata will be for `http://testserver:8000/saml/idp/sso/`
+ - With `SOCIAL_AUTH_SAML_FER_IDP_FAKER_DOCKER_PORT=11000`,
+   metadata will be for `http://testserver:11000/saml/idp/sso/`.
+
+
 ## Contributing
 
 This project is intended to be community-driven, so please, do not hesitate to get in touch if you

--- a/src/social_edu_federation/django/testing/views.py
+++ b/src/social_edu_federation/django/testing/views.py
@@ -1,6 +1,7 @@
 """social_edu_federation's Django testing views."""
 import uuid
 
+from django.conf import settings
 from django.http import HttpResponse
 from django.urls import reverse
 from django.views import View
@@ -135,6 +136,18 @@ class SamlFakeIdpMetadataView(View):
         sso_location = self.request.build_absolute_uri(
             reverse(self.local_idp_login_view_name)
         )
+
+        # Allow to manually override the port when this is used from inside Docker container
+        override_port = getattr(
+            settings,
+            "SOCIAL_AUTH_SAML_FER_IDP_FAKER_DOCKER_PORT",
+            None,
+        )
+        if override_port:
+            sso_location = sso_location.replace(
+                f":{self.request.get_port()}/",
+                f":{override_port}/",
+            )
 
         entity_descriptor_list = [
             generate_idp_metadata(

--- a/tests_django/tests/testing/test_views.py
+++ b/tests_django/tests/testing/test_views.py
@@ -20,6 +20,20 @@ def test_idp_metadata_view(client):
     assert b"md:EntityDescriptor" in response.content
 
 
+def test_idp_metadata_view_with_port_override(client, settings):
+    """Asserts EduFedMetadataView returns valid metadata."""
+    settings.SOCIAL_AUTH_SAML_FER_IDP_FAKER_DOCKER_PORT = 8060
+
+    response = client.get(
+        reverse("social_edu_federation_django_testing:idp_metadata"),
+        SERVER_PORT=8000,
+    )
+
+    assert response.status_code == 200
+    assert b"md:EntityDescriptor" in response.content
+    assert b"http://testserver:8060/saml/idp/sso/" in response.content
+
+
 def test_full_login_process(backend_settings, client, live_server, settings):
     """Asserts the nominal login process works."""
     settings.SOCIAL_AUTH_SAML_FER_FEDERATION_SAML_METADATA_URL = (


### PR DESCRIPTION
This allows to replace the port used to generate the metadata for the fake
IDP to provide an easy way to use it inside a docker container.

If the Django server runs on port 8000 and the docker maps 8000 to 11000
then we expect to use port 11000 ouside docker and therefore to have
port 11000 in the metadata.