### PR TITLE
👷(ci) fix the circle CI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           name: Install gitlint
           command: |
             pip install requests
-            pip install --user gitlint
+            pip install --user --upgrade gitlint
       - run:
           name: lint commit messages added to main
           command: |
@@ -57,7 +57,7 @@ jobs:
       - checkout
       - run:
           name: Install development dependencies
-          command: pip install --user .[dev,django,django-dev]
+          command: pip install --user --upgrade ".[dev,django,django-dev]"
       - run:
           name: Lint code with isort
           command: ~/.local/bin/isort --check-only src tests tests_django
@@ -84,7 +84,7 @@ jobs:
       - checkout
       - run:
           name: Install development dependencies
-          command: pip install --user .[dev]
+          command: pip install --user --upgrade ".[dev]"
       - run:
           name: Check the MANIFEST.in
           command: ~/.local/bin/check-manifest
@@ -149,7 +149,7 @@ jobs:
           command: ls dist/*
       - run:
           name: Install twine
-          command: pip install --user twine
+          command: pip install --user --upgrade "twine"
       - run:
           name: Upload built packages to PyPI
           command: ~/.local/bin/twine upload dist/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ dev =
     bandit==1.7.4
     black==22.3.0
     check-manifest==0.48
+    cryptography==37.0.2
     flake8==4.0.1
     httpretty==1.1.4
     ipython==8.4.0


### PR DESCRIPTION
The Circle CI cache seems to mix incompatible versions, we therefore enforce version update when possible.