### PR TITLE
🐛(backends) user's roles is a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+- Retrieve a *list* of roles from `eduPersonAffiliation` attribute
+
 ## [1.0.1] - 2022-09-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The authentication process can be summarized in few steps:
   - **urn:oid:0.9.2342.19200300.100.1.3** (mail)
     Provides us the user email, we use it as email address and username.
   - **urn:oid:1.3.6.1.4.1.5923.1.1.1.1** (eduPersonAffiliation)
-    Allows us to try to determine the role (student/professor).
+    Provides us the user's role(s) list.
     This is not mandatory.
 
   Fields we do not use:

--- a/src/social_edu_federation/defaults.py
+++ b/src/social_edu_federation/defaults.py
@@ -1,0 +1,25 @@
+"""Module providing default values for the social_edu_federation app."""
+from enum import Enum
+
+
+class EduPersonAffiliationEnum(Enum):
+    """Enumeration of eduPersonAffiliation values"""
+
+    STUDENT = "student"
+    FACULTY = "faculty"
+    STAFF = "staff"
+    EMPLOYEE = "employee"
+    MEMBER = "member"
+    AFFILIATE = "affiliate"
+    ALUM = "alum"
+    LIBRARY_WALK_IN = "library-walk-in"
+    RESEARCHER = "researcher"
+    RETIRED = "retired"
+    EMERITUS = "emeritus"
+    TEACHER = "teacher"
+    REGISTERED_READER = "registered-reader"
+
+    @classmethod
+    def get_choices(cls):
+        """Get the choices for the eduPersonAffiliation possible values (for Django mostly)."""
+        return [(member.value, member.value) for member in cls.__members__.values()]

--- a/src/social_edu_federation/django/testing/forms.py
+++ b/src/social_edu_federation/django/testing/forms.py
@@ -1,6 +1,8 @@
 """Forms for the social_edu_federation testing views"""
 from django import forms
 
+from social_edu_federation.defaults import EduPersonAffiliationEnum
+
 
 class SamlFakeIdpUserForm(forms.Form):
     """User attributes form, allows to customize SAML Auth Response."""
@@ -11,21 +13,7 @@ class SamlFakeIdpUserForm(forms.Form):
     display_name = forms.CharField(label="Full name")
     email = forms.CharField(label="Email")
     edu_person_affiliation = forms.MultipleChoiceField(
-        choices=(
-            ("student", "student"),
-            ("faculty", "faculty"),
-            ("staff", "staff"),
-            ("employee", "employee"),
-            ("member", "member"),
-            ("affiliate", "affiliate"),
-            ("alum", "alum"),
-            ("library-walk-in", "library-walk-in"),
-            ("researcher", "researcher"),
-            ("retired", "retired"),
-            ("emeritus", "emeritus"),
-            ("teacher", "teacher"),
-            ("registered-reader", "registered-reader"),
-        ),
+        choices=EduPersonAffiliationEnum.get_choices(),
         label="eduPersonAffiliation",
         required=False,
     )

--- a/src/social_edu_federation/django/testing/forms.py
+++ b/src/social_edu_federation/django/testing/forms.py
@@ -10,9 +10,8 @@ class SamlFakeIdpUserForm(forms.Form):
     given_name = forms.CharField(label="Last name")
     display_name = forms.CharField(label="Full name")
     email = forms.CharField(label="Email")
-    edu_person_affiliation = forms.ChoiceField(
+    edu_person_affiliation = forms.MultipleChoiceField(
         choices=(
-            (None, ""),
             ("student", "student"),
             ("faculty", "faculty"),
             ("staff", "staff"),
@@ -30,3 +29,7 @@ class SamlFakeIdpUserForm(forms.Form):
         label="eduPersonAffiliation",
         required=False,
     )
+
+    def clean_edu_person_affiliation(self):
+        """eduPersonAffiliation is a list of strings, not a single string."""
+        return ",".join(self.cleaned_data["edu_person_affiliation"])

--- a/tests/pipeline/test_user.py
+++ b/tests/pipeline/test_user.py
@@ -44,7 +44,7 @@ def backend_strategy_fixture():
                 "last_name": "surname",
                 "username": "mail",
                 "email": "mail",
-                "role": "eduPersonAffiliation",
+                "roles": ["eduPersonAffiliation"],
             },
             {
                 "fullname": "displayName",
@@ -52,7 +52,7 @@ def backend_strategy_fixture():
                 "last_name": "surname",
                 "username": "mail",
                 "email": "mail",
-                "role": "eduPersonAffiliation",
+                "roles": ["eduPersonAffiliation"],
             },
             id="all_data",
         ),
@@ -62,7 +62,7 @@ def backend_strategy_fixture():
                 "last_name": "surname",
                 "username": "mail",
                 "email": "mail",
-                "role": "eduPersonAffiliation",
+                "roles": ["eduPersonAffiliation"],
             },
             {
                 "fullname": "displayName",
@@ -70,7 +70,7 @@ def backend_strategy_fixture():
                 "last_name": "displayName",
                 "username": "mail",
                 "email": "mail",
-                "role": "eduPersonAffiliation",
+                "roles": ["eduPersonAffiliation"],
             },
             id="first name missing",
         ),
@@ -80,7 +80,7 @@ def backend_strategy_fixture():
                 "first_name": "givenName",
                 "username": "mail",
                 "email": "mail",
-                "role": "eduPersonAffiliation",
+                "roles": ["eduPersonAffiliation"],
             },
             {
                 "fullname": "displayName",
@@ -88,7 +88,7 @@ def backend_strategy_fixture():
                 "last_name": "displayName",
                 "username": "mail",
                 "email": "mail",
-                "role": "eduPersonAffiliation",
+                "roles": ["eduPersonAffiliation"],
             },
             id="last name missing",
         ),
@@ -98,14 +98,14 @@ def backend_strategy_fixture():
                 "last_name": "surname",
                 "username": "mail",
                 "email": "mail",
-                "role": "eduPersonAffiliation",
+                "roles": ["eduPersonAffiliation"],
             },
             {
                 "first_name": "givenName",
                 "last_name": "surname",
                 "username": "mail",
                 "email": "mail",
-                "role": "eduPersonAffiliation",
+                "roles": ["eduPersonAffiliation"],
             },
             id="full name missing",
         ),
@@ -142,7 +142,7 @@ def test_create_user_not_enough_data(backend_strategy, mocker):
     details = {
         "username": "mail",
         "email": "mail",
-        "role": "eduPersonAffiliation",
+        "roles": ["eduPersonAffiliation"],
     }
 
     create_user(backend, details, strategy, 42, some_kwargs=18)

--- a/tests_django/tests/test_metadata_store.py
+++ b/tests_django/tests/test_metadata_store.py
@@ -280,7 +280,7 @@ def test_saml_fer_backend_integration(cache_settings, mocker, settings):
         "attr_first_name": "urn:oid:2.5.4.42",
         "attr_full_name": "urn:oid:2.16.840.1.113730.3.1.241",
         "attr_last_name": "urn:oid:2.5.4.4",
-        "attr_role": "urn:oid:1.3.6.1.4.1.5923.1.1.1.1",
+        "attr_roles": "urn:oid:1.3.6.1.4.1.5923.1.1.1.1",
         "attr_user_permanent_id": "urn:oid:1.3.6.1.4.1.5923.1.1.1.6",
         "attr_username": "urn:oid:0.9.2342.19200300.100.1.3",
         #


### PR DESCRIPTION
## Purpose

Previous implementation was returning the raw `eduPersonAffiliation` attribute (a string), but for better understanding of its real type we should expect a list of roles.

## Proposal

Now return a list of roles (possibly empty) or `None` if not provided.
We keep the `None` type to allow to consider users without role versus information not provided.
