### PR TITLE
✨(feature) add logo parsing from metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+- Extract IDP's logo from metadata.
 
 ## [2.0.0] - 2022-11-28
 

--- a/lib/gitlint/gitlint_emoji.py
+++ b/lib/gitlint/gitlint_emoji.py
@@ -26,7 +26,7 @@ class GitmojiTitle(LineRule):
         title contains one of them.
         """
         gitmojis = requests.get(
-            "https://raw.githubusercontent.com/carloscuesta/gitmoji/master/src/data/gitmojis.json"
+            "https://raw.githubusercontent.com/carloscuesta/gitmoji/master/packages/gitmojis/src/gitmojis.json"
         ).json()["gitmojis"]
         emojis = [item["emoji"] for item in gitmojis]
         pattern = r"^({:s})\(.*\)\s[a-z].*$".format("|".join(emojis))

--- a/src/social_edu_federation/django/templates/social_edu_federation/available_idps_list.html
+++ b/src/social_edu_federation/django/templates/social_edu_federation/available_idps_list.html
@@ -90,10 +90,10 @@
 
       {% if latest_selected_idps %}
         <div class="submit-row">
-          {% for idp_name, idp_display_name in latest_selected_idps %}
-              <button class="btn-idp-link recently-used-idp" type="submit" name="idp" value="{{ idp_name }}">
-                {{ idp_display_name }}
-                <span class="remove-idp-btn" onclick="removeRecentIdpCookie(event, '{{ idp_name }}')">x</span>
+          {% for idp in latest_selected_idps %}
+              <button class="btn-idp-link recently-used-idp" type="submit" name="idp" value="{{ idp.name }}">
+                {{ idp.edu_fed_data.display_name }}
+                <span class="remove-idp-btn" onclick="removeRecentIdpCookie(event, '{{ idp.name }}')">x</span>
               </button>
           {% endfor %}
         </div>
@@ -102,8 +102,10 @@
       {% endif %}
 
       <div class="submit-row">
-        {% for idp_name, idp_display_name in available_idps %}
-            <button class="btn-idp-link" type="submit" name="idp" value="{{ idp_name }}" onclick="storeRecentIdpCookie('{{ idp_name }}')">{{ idp_display_name }}</button>
+        {% for idp in available_idps %}
+            <button class="btn-idp-link" type="submit" name="idp" value="{{ idp.name }}" onclick="storeRecentIdpCookie('{{ idp.name }}')">
+              {% if idp.edu_fed_data.logo %}<img src="{{ idp.edu_fed_data.logo }}" width="16" height="16"/>&nbsp;{% endif %}{{ idp.edu_fed_data.display_name }}
+            </button>
         {% endfor %}
       </div>
     </form>

--- a/src/social_edu_federation/parser.py
+++ b/src/social_edu_federation/parser.py
@@ -124,6 +124,14 @@ class FederationMetadataParser(OneLogin_Saml2_IdPMetadataParser):
             entity_descriptor,
             "./md:Organization/md:OrganizationDisplayName",
         )
+        extra_data["logo"] = (
+            cls.get_xml_node_text(
+                entity_descriptor,
+                "./md:IDPSSODescriptor/md:Extensions/mdui:UIInfo/mdui:Logo",
+            )
+            .replace("\n", "")
+            .replace(" ", "")
+        )
 
         return extra_data
 

--- a/src/social_edu_federation/testing/saml_tools.py
+++ b/src/social_edu_federation/testing/saml_tools.py
@@ -151,6 +151,9 @@ _ENTITY_DESCRIPTOR_TEMPLATE = """\
             <mdui:UIInfo>
                 {ui_info_display_names}
                 <mdui:Description xml:lang="fr">Some description</mdui:Description>
+                <mdui:Logo height="16" width="16">
+                    data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=
+                </mdui:Logo>
             </mdui:UIInfo>
         </md:Extensions>
         <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -40,6 +40,29 @@ def test_idp_no_display_name():
         "display_name": "http://edu.example.com/adfs/services/trust",
         "organization_display_name": "OrganizationDName",
         "organization_name": "OrganizationName",
+        "logo": (
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgd"
+            "z34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0"
+            "U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ"
+            "/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIH"
+            "oCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u99"
+            "2bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx"
+            "3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryT"
+            "t2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12Ryo"
+            "hqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F"
+            "3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96Cu"
+            "tRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V"
+            "/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQ"
+            "l5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7"
+            "O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTq"
+            "WbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17M"
+            "mWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ"
+            "0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7i"
+            "h8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1G"
+            "Hj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik"
+            "9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UN"
+            "z8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII="
+        ),
     }
     assert idp_config["x509cert"].startswith(
         "MIIFdjCCA14CAQAwDQYJKoZIhvcNAQENBQAwgYAxCzAJ"
@@ -112,6 +135,7 @@ def test_renater_idps_metadata():
             "display_name": "idp de test\nmathrice-plm-team-bdx-novembre-2016\n",
             "organization_display_name": "",
             "organization_name": "",
+            "logo": "",
         },
         "entityId": "http://idp-pre.math.cnrs.fr/idp/shibboleth",
         "name": "idp-de-test-mathrice-plm-team-bdx-novembre-2016",
@@ -142,5 +166,55 @@ def test_renater_idps_metadata():
             "ogmPeIhP8FGG8eTOyuLKSVE32jl4OlmQqpmyEABoKz5PVmJD/iRVSpvYu4IrGbo6"
             "DuE8DAZbM+WVzVB27FGSjYnxoAY7H1EClMQ1TGUg6eEP9RkWzjWoEZZyAIpjFHdE"
             "zfif9VATaFW9Mr2e0S/4"
+        ),
+    }
+
+    assert identity_providers["centre-hospitalier-universitaire-de-limoges"] == {
+        "edu_fed_data": {
+            "display_name": "Centre Hospitalier Universitaire de Limoges\n",
+            "organization_display_name": "CHU de Limoges",
+            "organization_name": "CHU de Limoges",
+            "logo": (
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9h"
+                "AAAACXBIWXMAAC4jAAAuIwF4pT92AAAB6klEQVR42qWTTWsTURSG+zcEF+78BYJrce"
+                "Han+BCQdqFYKxiUwtupFBoIzSpkeajWAsuGjNJtaHVNGmatMVmhphEk6YSaWWSfuSj"
+                "mqaTzDxORtQEi0Z94YXL4Z7n3HM4twfoafPQXzhIW2KHasdlGuox3egHQC1XUDKbaJ"
+                "rKk/WrrGw50OpV1Oqn7gAlkxn5/EW0RgP32hViH9wcxSxUpy6hNZXfAgzt95rYOXWW"
+                "5v4BaXlRb6PEZ38fhzOXuwOoB3qC6ynK+yxS7hnFfADlYwS1XvljCyzmq4ysF1GaGs"
+                "WbZgKDF3i3fJvGzpuuhkjfwjanbSns0h43TJOE7z/g4ZiFOcGD4PUaF/2CD7/PZ5xf"
+                "zr3oBAibFYYiMqm9I85NiUzYJlAUhXAozJ1b/Ty227k3YMbpcBhJbqfr1xlomsZu7Q"
+                "vXFuYZtVpJp9LMTE8zMjzM2uoqg3cHsIyO8TaRwOVwdgIq9Tq9rwNcfzXP9mGVSDqF"
+                "bXwcURSJRaMGfCkYJL6xgVWPFwqFTkCuXOLMpJX+ZWM7kWWZZDJJJpNBkiTEeJytXM"
+                "6o/t2qqv4EqHqFRwkRafcbudV/rVYjm83imZ01Bun1PMcnCEa85darOOkftCufzxPV"
+                "W1iJRAxQaClEQ9/UExfpX/XfgK9hJqAg9gc+TgAAAABJRU5ErkJggg=="
+            ),
+        },
+        "entityId": "http://auth.chu-limoges.fr/adfs/services/trust",
+        "name": "centre-hospitalier-universitaire-de-limoges",
+        "singleLogoutService": {
+            "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+            "url": "https://auth.chu-limoges.fr/adfs/ls/",
+        },
+        "singleSignOnService": {
+            "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+            "url": "https://auth.chu-limoges.fr/adfs/ls/",
+        },
+        "x509cert": (
+            "MIIC4jCCAcqgAwIBAgIQVvZQS8VqPZBDOtoSFpZqCDANBgkqhkiG9w0BAQsFADAt"
+            "MSswKQYDVQQDEyJBREZTIFNpZ25pbmcgLSBhdXRoLmNodS1saW1vZ2VzLmZyMB4X"
+            "DTIxMDQxMjEzMDA1MFoXDTIyMDQxMjEzMDA1MFowLTErMCkGA1UEAxMiQURGUyBT"
+            "aWduaW5nIC0gYXV0aC5jaHUtbGltb2dlcy5mcjCCASIwDQYJKoZIhvcNAQEBBQAD"
+            "ggEPADCCAQoCggEBAJaaXamgmPnMIhthb9Y/1KJPx5W4VMoAyUvaNGWdP+FdRejU"
+            "AagNL2FZhryuap0N5q/XFy6iZWoor4/YZo4lm1OCjb+ck2USG6WmTqqyJtBkECB2"
+            "wWjpkRfqVm65Aabez1jwNFXeJcTx7UslSSQXeHYBDBSr5swSuk5VZKJpCdQAodFh"
+            "O4S4Qs3YKiGDx9FOYIhLWxvhIuqmr3sOEUF84pxZxUVTb2D1U5LzRUxX9LBuUbk/"
+            "PsLviQYJEkRs72sajDAzvwwrP0Iv2ewz12vCbrwkUAIyDkmIn39wqN01anvQ3eK5"
+            "gaV3HRy2G/h2lFC6kC0LrblCVtj6BFuWOjKLboMCAwEAATANBgkqhkiG9w0BAQsF"
+            "AAOCAQEABcGrSH24Grn5CBm6XCPPsHM/bHQpjv4OJKHhoRgIYzw0f7X2h87jQMs3"
+            "87KOEEqEuzp9jDmtep8SnITUMFvJ4SJqX58VOrbnkt/MsfdnXXSh4Bh7U08S5Jvv"
+            "4vlzYKe1W+Dudsrj7+/EJiorUdo5/Mdb5BVEEatqBcXEv6990rv8ilNxgBakbJrp"
+            "zohfpxuiGRo/4cnKfe5okZ3bOQ+VWNc95n+5b/Jp+0Wu17B49Y+hgB19t1cbnsqK"
+            "nl2YHnY9XQCqq5Au4GhmDWYuessD3vviQrux+t/IBbYEw8s7KugEAmX3W+FjO5MV"
+            "rMN4tw3LLMDGO89uGyVEHNeR8LNXSQ=="
         ),
     }


### PR DESCRIPTION
## Purpose

The IDP metadata may provide a logo as `data:image/png;base64`, we want to fetch it along with the other information about the IDP we parse.

## Proposal

- [x] Extract the logo data when parsing the metadata.
- [x] Provide an example using the logo in the default Django IDP list implementation