### PR TITLE
🐛(core) fetch all roles list items in response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+- `eduPersonAffiliation` attribute can be provided as a list,
+  not only a string comma-separated.
 
 ## [2.1.0] - 2023-01-12
 

--- a/src/social_edu_federation/django/testing/forms.py
+++ b/src/social_edu_federation/django/testing/forms.py
@@ -17,7 +17,3 @@ class SamlFakeIdpUserForm(forms.Form):
         label="eduPersonAffiliation",
         required=False,
     )
-
-    def clean_edu_person_affiliation(self):
-        """eduPersonAffiliation is a list of strings, not a single string."""
-        return ",".join(self.cleaned_data["edu_person_affiliation"])

--- a/src/social_edu_federation/testing/saml_tools.py
+++ b/src/social_edu_federation/testing/saml_tools.py
@@ -205,15 +205,22 @@ def format_edu_person_affiliation_attribute(edu_person_affiliation):
     if not edu_person_affiliation:
         return ""
 
-    return f"""
-        <saml2:Attribute
-        FriendlyName="eduPersonAffiliation"
-        Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.1"
-        NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
-    >
-        <saml2:AttributeValue>{edu_person_affiliation}</saml2:AttributeValue>
-    </saml2:Attribute>
-    """
+    return (
+        """
+                <saml2:Attribute
+                FriendlyName="eduPersonAffiliation"
+                Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.1"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+            >
+        """
+        + "\n".join(
+            f"<saml2:AttributeValue>{attribute}</saml2:AttributeValue>"
+            for attribute in edu_person_affiliation
+        )
+        + """
+            </saml2:Attribute>
+        """
+    )
 
 
 def _add_x509_key_descriptors(metadata, cert) -> str:
@@ -281,6 +288,10 @@ def generate_idp_federation_metadata(entity_descriptor_list=None, **kwargs):
 
 def generate_auth_response(in_response_to, acs_url, **kwargs):
     """Generates an SAML authentication response."""
+    edu_person_affiliation = kwargs.get("edu_person_affiliation", [])
+    if not isinstance(edu_person_affiliation, (list, tuple)):
+        edu_person_affiliation = [edu_person_affiliation]
+
     response_attributes = {
         "in_response_to": in_response_to,
         "issuer": "http://edu.example.com/adfs/services/trust",
@@ -295,7 +306,7 @@ def generate_auth_response(in_response_to, acs_url, **kwargs):
         "display_name": "Rick Sanchez",
         "email": "rsanchez@samltest.id",
         "edu_person_affiliation_attribute": format_edu_person_affiliation_attribute(
-            kwargs.get("edu_person_affiliation", None),
+            edu_person_affiliation,
         ),
     }
     response_attributes.update(kwargs)

--- a/tests/backends/test_saml_fer.py
+++ b/tests/backends/test_saml_fer.py
@@ -243,7 +243,12 @@ def test_idp_overridden_setting():
         pytest.param(
             "eduPersonAffiliation,anotherRole",
             ["eduPersonAffiliation", "anotherRole"],
-            id="two-roles",
+            id="two-roles-string",
+        ),
+        pytest.param(
+            ["eduPersonAffiliation", "anotherRole"],
+            ["eduPersonAffiliation", "anotherRole"],
+            id="two-roles-list",
         ),
         pytest.param(
             "",


### PR DESCRIPTION
## Purpose

By default the SAMLIdentityProvider class only fetches the first item of attributes. In the case of user roles, we were expecting only one attribute too, with role separated by comma, but it appears this is a list of attributes which is in response.

We now manage both cases.

## Proposal

- [x] Expect a list of items for the roles attribute